### PR TITLE
Handle null GitHub repository results gracefully

### DIFF
--- a/GithubUsersTask.Tests/Services/GithubUsersServiceTests.cs
+++ b/GithubUsersTask.Tests/Services/GithubUsersServiceTests.cs
@@ -126,6 +126,35 @@ namespace GithubUsersTask.Tests.Services
         }
 
         [Fact]
+        public async Task GetUserAsync_Success_Handles_NullRepositories()
+        {
+            // Arrange
+            var username = "user";
+            var githubUserUrl = string.Format("https://api.github.com/users/{0}", username);
+            var githubUserRepoUrl = string.Format("https://api.github.com/users/{0}/repos", username);
+            var userResult = new GithubUser
+            {
+                UserName = username,
+                Name = "User",
+                RepoUrl = githubUserRepoUrl
+            };
+
+            var githubApiClientMock = new Mock<IGithubApiClient>(MockBehavior.Strict);
+            githubApiClientMock.Setup(client => client.GetAsync<GithubUser>(githubUserUrl)).ReturnsAsync(userResult);
+            githubApiClientMock.Setup(client => client.GetAsync<IEnumerable<GithubUserRepo>>(githubUserRepoUrl)).ReturnsAsync((IEnumerable<GithubUserRepo>)null);
+
+            GithubUsersService githubUsersService = new GithubUsersService(githubApiClientMock.Object);
+
+            // Act
+            GithubUser result = await githubUsersService.GetUserAsync(username);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Repositories);
+            Assert.Empty(result.Repositories);
+        }
+
+        [Fact]
         public async Task GetUserAsync_Success_Returns_Null_WhenUserNotFound()
         {
             // Arrange

--- a/GithubUsersTask/Services/GithubUsersService.cs
+++ b/GithubUsersTask/Services/GithubUsersService.cs
@@ -35,7 +35,7 @@ namespace GithubUsersTask.Services
             }
 
             // get user's repositories using repos_url
-            var userRepositories = await GetUserRepositoriesAsync(user.RepoUrl);
+            var userRepositories = await GetUserRepositoriesAsync(user.RepoUrl) ?? Enumerable.Empty<GithubUserRepo>();
 
             // filter top 5 starred repository
             user.Repositories = userRepositories.OrderByDescending(r => r.Stars).Take(5);


### PR DESCRIPTION
## Summary
- ensure GithubUsersService treats null repository responses as empty collections
- add unit coverage verifying repository list defaults to empty when the API returns null

## Testing
- ⚠️ `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_69038d0b845c8332b3a08445b3e0846c