### PR TITLE
Consolidate all open Dependabot security updates into one change

### DIFF
--- a/GithubUsersTask.Common/GithubUsersTask.Common.csproj
+++ b/GithubUsersTask.Common/GithubUsersTask.Common.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/GithubUsersTask.Common/packages.config
+++ b/GithubUsersTask.Common/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net45" />
 </packages>

--- a/GithubUsersTask.Tests/App.config
+++ b/GithubUsersTask.Tests/App.config
@@ -23,7 +23,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/GithubUsersTask.Tests/GithubUsersTask.Tests.csproj
+++ b/GithubUsersTask.Tests/GithubUsersTask.Tests.csproj
@@ -73,7 +73,7 @@
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />

--- a/GithubUsersTask.Tests/packages.config
+++ b/GithubUsersTask.Tests/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Moq" version="4.12.0" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net45" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
@@ -19,7 +19,7 @@
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
   <package id="System.Linq" version="4.3.0" targetFramework="net45" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net45" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
@@ -34,7 +34,7 @@
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net45" />
   <package id="System.Threading" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net45" />

--- a/GithubUsersTask/GithubUsersTask.csproj
+++ b/GithubUsersTask/GithubUsersTask.csproj
@@ -109,7 +109,7 @@
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>

--- a/GithubUsersTask/Web.config
+++ b/GithubUsersTask/Web.config
@@ -22,7 +22,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/GithubUsersTask/packages.config
+++ b/GithubUsersTask/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net45" />
   <package id="SimpleInjector" version="4.6.0" targetFramework="net45" />
   <package id="SimpleInjector.Integration.Web" version="4.6.0" targetFramework="net45" />
   <package id="SimpleInjector.Integration.Web.Mvc" version="4.6.0" targetFramework="net45" />


### PR DESCRIPTION
Replaces the five open Dependabot PRs with a single consolidated update, and fixes up the project/config files that Dependabot leaves behind.

## Package bumps

| Package | From | To | Project | Supersedes |
| --- | --- | --- | --- | --- |
| Newtonsoft.Json | 11.0.1 | 13.0.2 | `GithubUsersTask` | #8 |
| Newtonsoft.Json | 11.0.1 | 13.0.2 | `GithubUsersTask.Tests` | #7 |
| Newtonsoft.Json | 11.0.1 | 13.0.2 | `GithubUsersTask.Common` | #6 |
| System.Text.RegularExpressions | 4.3.0 | 4.3.1 | `GithubUsersTask.Tests` | #2 |
| System.Net.Http | 4.3.0 | 4.3.4 | `GithubUsersTask.Tests` | #1 |

## Why this isn't just the five diffs squashed together

Each Dependabot PR only edits `packages.config`. On a classic `packages.config` project that is not enough — the assembly reference paths and binding redirects live in the `.csproj` and `Web.config`/`App.config`, and they still pointed at 11.0.1. Taking any of those PRs as-is would restore Newtonsoft.Json 13.0.2 into `packages\` while every project kept referencing `packages\Newtonsoft.Json.11.0.1\...`, which does not exist after restore.

So on top of the `packages.config` bumps this also updates:

- **HintPath** in all three project files → `..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll`
- **Reference identity** in `GithubUsersTask.Common.csproj` → `Version=13.0.0.0` (13.0.2 ships assembly version 13.0.0.0)
- **Binding redirects** for Newtonsoft.Json in `GithubUsersTask/Web.config` and `GithubUsersTask.Tests/App.config` → `oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"`

`System.Net.Http` and `System.Text.RegularExpressions` need no project or config changes. The test project consumes `System.Net.Http` as a plain framework reference (`<Reference Include="System.Net.Http" />`, no HintPath), and neither package has a binding redirect in `App.config`.

## Files changed

- `GithubUsersTask/packages.config`, `GithubUsersTask/GithubUsersTask.csproj`, `GithubUsersTask/Web.config`
- `GithubUsersTask.Common/packages.config`, `GithubUsersTask.Common/GithubUsersTask.Common.csproj`
- `GithubUsersTask.Tests/packages.config`, `GithubUsersTask.Tests/GithubUsersTask.Tests.csproj`, `GithubUsersTask.Tests/App.config`

## Verification

All eight touched XML files were checked for well-formedness, and there are no remaining references to `Newtonsoft.Json.11.0.1` or `Version=11.0.0.0` anywhere in the repo.

A compile/test run was **not** performed: this is a .NET Framework 4.5 / MSBuild solution and the environment this was prepared in is Linux with no MSBuild, Mono, or NuGet CLI available. Please run a `nuget restore` plus a full build and the xunit suite on Windows before merging.

## Follow-up

The five superseded Dependabot PRs (#8, #7, #6, #2, #1) are being closed in favour of this one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MWotEs9dLmPEzC8pVjjktU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the JSON processing library to version 13.0.2.
  * Updated related runtime configuration to ensure compatibility with the newer library version.
  * Refreshed supporting networking and regular-expression packages used by the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->